### PR TITLE
Bugfixes

### DIFF
--- a/README
+++ b/README
@@ -28,7 +28,7 @@ Debian
 ------
 
 Please build the package:
-$ dpkg-buildpackage -rfakeroot -uc- b
+$ dpkg-buildpackage -rfakeroot -uc -b
 
 and install it
 Then, modify /etc/default/redis-snmp

--- a/redis-snmp
+++ b/redis-snmp
@@ -184,7 +184,7 @@ my @types = (
     'Gauge32',      # 14
     'Gauge32',      # 15
     'Gauge32',      # 16
-    'Gauge32',      #17
+    'Counter64',    # 17
 
 );
 
@@ -205,7 +205,7 @@ my @newkeys = (
     'redisPubsubChannels',          # 14
     'redisPubsubPatterns',          # 15
     'redisUptime',                  # 16
-    'redisUsedMemoryRss',           #17
+    'redisUsedMemoryRss',           # 17
 );
 
 run() unless caller();


### PR DESCRIPTION
Hi,

I did two changes: (1) there is a typo in the README and if you copy the command line for building the debian package then you get an error, and (2) if I install redis-snmp and use snmpwalk I get the following result:
.1.3.6.1.4.1.20267.400.1.1.0 = Gauge32: 6
.1.3.6.1.4.1.20267.400.1.2.0 = Gauge32: 1
.1.3.6.1.4.1.20267.400.1.3.0 = Counter64: 27941504 Bytes
.1.3.6.1.4.1.20267.400.1.5.0 = Counter64: 822583
.1.3.6.1.4.1.20267.400.1.6.0 = Counter64: 4635424
.1.3.6.1.4.1.20267.400.1.7.0 = Counter32: 73721
.1.3.6.1.4.1.20267.400.1.8.0 = Counter32: 66578
.1.3.6.1.4.1.20267.400.1.9.0 = Gauge32: 0
.1.3.6.1.4.1.20267.400.1.10.0 = Counter64: 0
.1.3.6.1.4.1.20267.400.1.11.0 = Counter64: 0
.1.3.6.1.4.1.20267.400.1.12.0 = Counter64: 2101050
.1.3.6.1.4.1.20267.400.1.13.0 = Counter64: 327
.1.3.6.1.4.1.20267.400.1.14.0 = Gauge32: 1
.1.3.6.1.4.1.20267.400.1.15.0 = Gauge32: 0
.1.3.6.1.4.1.20267.400.1.16.0 = Gauge32: 379790 Seconds
.1.3.6.1.4.1.20267.400.1.17.0 = Wrong Type (should be Counter64): Gauge32: 33443840

In the line you see the hint from snmpwalk that the type is wrong. This is the second change I did (I replaced the type Gauge32 by Counter64). After this change the output of snmpwalk has no more errors).